### PR TITLE
Refactoring, Cleanup and Simplified metadata storage

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/sirupsen/logrus v1.6.0
-	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.5.1
+	github.com/twmb/murmur3 v1.1.3
 )

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/sirupsen/logrus v1.6.0
+	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -62,6 +62,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/twmb/murmur3 v1.1.3 h1:D83U0XYKcHRYwYIpBKf3Pks91Z0Byda/9SJ8B6EMRcA=
+github.com/twmb/murmur3 v1.1.3/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/storage/helpers.go
+++ b/storage/helpers.go
@@ -1,79 +1,8 @@
 package storage
 
 import (
-	"crypto/rand"
-	"io"
+	"encoding/binary"
 )
-
-//
-//var (
-//	ErrInvalidKey = errors.New("corrupted message key should be 8 bytes")
-//)
-
-//
-//func (m KVPair) GetKeyAsUint64() (uint64, error) {
-//	if len(m.Key) != 8 {
-//		return -1, ErrInvalidKey
-//	}
-//	return getUint64(m.Key), nil
-//}
-//
-//func UInt64ToBytes(n uint64) []byte {
-//	result := make([]byte, 8)
-//	writeUint64(result, n)
-//	return result
-//}
-
-func uInt16ToBytes(partition uint16) []byte {
-	buf := make([]byte, 2)
-	writeUint16(buf, partition)
-
-	return buf
-}
-
-// writeUint64 encodes a little-endian uint64 into a byte slice.
-//func writeUint64(buf []byte, n uint64) {
-//	_ = buf[7] // Force one bounds check. See: golang.org/issue/14808
-//	buf[0] = byte(n)
-//	buf[1] = byte(n >> 8)
-//	buf[2] = byte(n >> 16)
-//	buf[3] = byte(n >> 24)
-//	buf[4] = byte(n >> 32)
-//	buf[5] = byte(n >> 40)
-//	buf[6] = byte(n >> 48)
-//	buf[7] = byte(n >> 56)
-//}
-
-// getUint16 decodes a little-endian uint16 from a byte slice.
-func getUint16(buf []byte) (n uint16) {
-	_ = buf[1] // Force one bounds check. See: golang.org/issue/14808
-	n |= uint16(buf[0])
-	n |= uint16(buf[1]) << 8
-
-	return
-}
-
-//
-//// getUint64 decodes a little-endian uint64 from a byte slice.
-//func getUint64(buf []byte) (n uint64) {
-//	_ = buf[7] // Force one bounds check. See: golang.org/issue/14808
-//	n |= uint64(buf[0])
-//	n |= uint64(buf[1]) << 8
-//	n |= uint64(buf[2]) << 16
-//	n |= uint64(buf[3]) << 24
-//	n |= uint64(buf[4]) << 32
-//	n |= uint64(buf[5]) << 40
-//	n |= uint64(buf[6]) << 48
-//	n |= uint64(buf[7]) << 56
-//	return
-//}
-
-// writeUint16 encodes a little-endian uint16 into a byte slice.
-func writeUint16(buf []byte, n uint16) {
-	_ = buf[1] // Force one bounds check. See: golang.org/issue/14808
-	buf[0] = byte(n)
-	buf[1] = byte(n >> 8)
-}
 
 func concatSlices(slices ...[]byte) []byte {
 	var totalLen int
@@ -88,20 +17,10 @@ func concatSlices(slices ...[]byte) []byte {
 	return tmp
 }
 
-// newUUID returns a UUID based on bytes read from crypto/rand.Reader
-func newUUID() []byte {
-	uuid := make([]byte, 16)
-	//nolint:errcheck,gosec //cannot fail
-	io.ReadFull(rand.Reader, uuid[:])
-	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
-	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
-	return uuid
-}
-
 func bytesToSliceUInt16(src []byte) []uint16 {
 	var dest []uint16
 	for i := 0; i < len(src); i += 2 {
-		dest = append(dest, getUint16(src[i:i+2]))
+		dest = append(dest, binary.BigEndian.Uint16(src[i:i+2]))
 	}
 	return dest
 }
@@ -111,7 +30,7 @@ func sliceUInt16ToBytes(src []uint16) []byte {
 	result := make([]byte, 0, len(src)*2)
 
 	for _, p := range src {
-		writeUint16(buf, p)
+		binary.BigEndian.PutUint16(buf, p)
 		result = append(result, buf...)
 	}
 	return result

--- a/storage/message.go
+++ b/storage/message.go
@@ -78,7 +78,7 @@ func NewMessageWithRandomID(priority uint16, body []byte) Message {
 	//if using global rand singleton source is found to be a Mutex bottleneck
 	// move this in a struct with its
 	// own pool of random sources, but probably this will never happen.
-	size, err := rand.Read(randomMsgID) //nolint:gosec
+	size, err := rand.Read(randomMsgID) //nolint:gosec //is a hash not crypto
 	if err != nil || size != msgIDSize {
 		// this means the node has bigger issues than this, most likely it needs to be terminated
 		logrus.StandardLogger().WithError(err).Error("the node ran out of entropy")

--- a/storage/metadata.go
+++ b/storage/metadata.go
@@ -8,20 +8,31 @@ import (
 // Is is stored in the metadata table with the topicUUID and ID as the key
 // The rest of its properties are stored in the body
 type ConsumerMetadata struct {
-	TopicUUID  string    `json:"-"` //it is in the key
+	TopicHash  uint32    `json:"-"` //it is in the key
 	ConsumerID string    `json:"-"` //it is in the key
 	LastSeen   time.Time `json:"s"`
 }
 
+func (cm ConsumerMetadata) ConsumerIDBytes() []byte {
+	//TODO avoid memory allocs
+	return []byte(cm.ConsumerID)
+}
+
 // ConsumerPartitions is a container for all Partitions owned by a ConsumerID
 type ConsumerPartitions struct {
-	ConsumerID string
-	Partitions []uint16
+	TopicHash  uint32   //it is in the key
+	ConsumerID string   //is in the key
+	Partitions []uint16 //is the body
+}
+
+func (cm ConsumerPartitions) ConsumerIDBytes() []byte {
+	//TODO avoid memory allocs
+	return []byte(cm.ConsumerID)
 }
 
 // TopicMetadata holds the basic info for a topic
 type TopicMetadata struct {
 	TopicID         string `json:"-"` //it is already in the Key
-	TopicUUID       []byte `json:"u"`
+	TopicHash       uint32 `json:"u"`
 	PartitionsCount int    `json:"p"`
 }

--- a/storage/storage_messages.go
+++ b/storage/storage_messages.go
@@ -1,20 +1,31 @@
 package storage
 
 import (
+	"encoding/binary"
+
 	"github.com/dgraph-io/badger/v2"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	// length in bytes of the partition
+	partitionSize = 2
+	// length in bytes for the priority
+	prioritySize = 2
+	// msg id size in bytes
+	msgIDSize = 6
 )
 
 /* LocalStorageMessages handles all the topics logic relative to the local messages.
  All the Input and Output keys of all methods will NOT contain the prefix (they are relative keys)
 
 The keys are as following, without delimiters:
-<topicUUID><partition><priority><msgID> => body
-<32bytes>  <2bytes>  <2bytes>  <6bytes>
+<topicHash><partition><priority><msgID> => body
+<4bytes>  <2bytes>  <2bytes>  <6bytes>
 
 
 When calling *LocalStorage the struct prefix has to be used. In badgerDB the full key would be
-t:<topicUUID><partition><priority><msgID> because this struct receives a prefix of "t:"
+t:<topicHash><partition><priority><msgID> because this struct receives a prefix of "t:"
 */
 type LocalStorageMessages struct {
 	db     *badger.DB
@@ -26,40 +37,36 @@ type LocalStorageMessages struct {
 // Upsert creates a write transaction for a specific topic and partition.
 // If the messages does not exists it will create them, otherwise their body will be replaced
 // the Keys of KVPairs should NOT have the topic/partition prefixes, they are prepended in this method
-func (m *LocalStorageMessages) Upsert(topicUUID []byte, partition uint16, batch []Message) error {
-	prefix := m.prefixForTopicAndPart(topicUUID, partition)
-
+func (m *LocalStorageMessages) Upsert(topicHash uint32, partition uint16, batch []Message) error {
 	kvs := make([]KVPair, len(batch))
 	for i := range batch {
 		if !IsMsgBodyValid(batch[i].Body) {
 			return ErrMessageInvalid
 		}
 		kvs[i] = KVPair{
-			Key: batch[i].Key(),
+			Key: m.keyForMessage(topicHash, partition, batch[i]),
 			Val: batch[i].Body,
 		}
 	}
 
-	return m.parent.WriteBatch(prefix, kvs)
+	return m.parent.WriteBatch(nil, kvs)
 }
 
 // Ack removes the messages to be seen by any consumer
 // The Body of the Message can be empty (Ack operation does not need it)
-func (m *LocalStorageMessages) Ack(topicUUID []byte, partition uint16, batch []Message) error {
-	prefix := m.prefixForTopicAndPart(topicUUID, partition)
-
+func (m *LocalStorageMessages) Ack(topicHash uint32, partition uint16, batch []Message) error {
 	kvs := make([][]byte, len(batch))
 	for i := range batch {
-		kvs[i] = batch[i].Key()
+		kvs[i] = m.keyForMessage(topicHash, partition, batch[i])
 	}
 
-	return m.parent.DeleteBatch(prefix, kvs)
+	return m.parent.DeleteBatch(nil, kvs)
 }
 
 // GetLowestPriority reads in a transaction the messages with the lowest priority
 // the Keys of KVPairs should NOT have the topic/partition prefixes, they are prepended in this method
-func (m *LocalStorageMessages) GetLowestPriority(topicUUID []byte, partition uint16, limit int) ([]Message, error) {
-	prefix := m.prefixForTopicAndPart(topicUUID, partition)
+func (m *LocalStorageMessages) GetLowestPriority(topicHash uint32, partition uint16, limit int) ([]Message, error) {
+	prefix := m.prefixForTopicAndPart(topicHash, partition)
 
 	msgs, err := m.parent.ReadFirstsKVPairs(prefix, limit)
 	result := make([]Message, len(msgs))
@@ -74,9 +81,17 @@ func (m *LocalStorageMessages) GetLowestPriority(topicUUID []byte, partition uin
 	return result, err
 }
 
-func (m *LocalStorageMessages) prefixForTopicAndPart(topicUUID []byte, partition uint16) []byte {
-	partitionAsBytes := uInt16ToBytes(partition)
-	//these are concat without a delimiter! because they have fixed sizes
-	prefix := concatSlices(m.prefix, topicUUID, partitionAsBytes)
+func (m *LocalStorageMessages) prefixForTopicAndPart(topicHash uint32, partition uint16) []byte {
+	prefix := make([]byte, len(m.prefix)+topicHashSize+partitionSize)
+	offset := 0
+	copy(prefix[offset:], m.prefix)
+	offset += len(m.prefix)
+	binary.BigEndian.PutUint32(prefix[offset:], topicHash)
+	offset += topicHashSize
+	binary.BigEndian.PutUint16(prefix[offset:], partition)
 	return prefix
+}
+
+func (m *LocalStorageMessages) keyForMessage(topicHash uint32, partition uint16, msg Message) []byte {
+	return append(m.prefixForTopicAndPart(topicHash, partition), msg.Key()...)
 }

--- a/storage/storage_messages_integration_test.go
+++ b/storage/storage_messages_integration_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -15,85 +14,88 @@ type InMemoryMessagesSuite struct {
 
 func (suite *InMemoryMessagesSuite) SetupTest() {
 	storage, err := NewLocalStorageInMemory(logrus.StandardLogger())
-	suite.Assert().NoError(err)
+	suite.Require().NoError(err)
 
 	suite.messages = storage.LocalMessages()
 }
 
 // Test that removing a msg does not affect other partition or priority
 func (suite *InMemoryMessagesSuite) TestDelete() {
-	key := []byte("key3")
-	topic := []byte("singleton")
+	topicHash := uint32(42)
 
-	p1 := keysToMsgs([][]byte{key}, 87)
-	err := suite.messages.Upsert(topic, 42, p1)
-	suite.Assert().NoError(err)
+	p1 := NewMessageWithRandomID(87, []byte("body_p1"))
+	err := suite.messages.Upsert(topicHash, 42, []Message{p1})
+	suite.Require().NoError(err)
 
 	//different priority
-	p2 := keysToMsgs([][]byte{key}, 0)
-	err = suite.messages.Upsert(topic, 42, p2)
-	suite.Assert().NoError(err)
+	p2 := NewMessageWithRandomID(0, []byte("body_p2"))
+	err = suite.messages.Upsert(topicHash, 42, []Message{p2})
+	suite.Require().NoError(err)
 
 	//different partition
-	p3 := keysToMsgs([][]byte{key}, 87)
-	err = suite.messages.Upsert(topic, 87, p3)
-	suite.Assert().NoError(err)
+	p3 := NewMessageWithRandomID(87, []byte("body_p3"))
+	err = suite.messages.Upsert(topicHash, 87, []Message{p3})
+	suite.Require().NoError(err)
 
-	err = suite.messages.Ack(topic, 42, p1)
-	suite.Assert().NoError(err)
+	err = suite.messages.Ack(topicHash, 42, []Message{p1})
+	suite.Require().NoError(err)
 
 	//this should have the priority 0 left in it
-	result, err := suite.messages.GetLowestPriority(topic, 42, 100)
-	suite.Assert().NoError(err)
-	suite.Assert().Len(result, 1)
-	suite.Assert().Equal(key, result[0].ID)
-	suite.Assert().Equal(uint16(0), result[0].Priority)
+	result, err := suite.messages.GetLowestPriority(topicHash, 42, 100)
+	suite.Require().NoError(err)
+	suite.Require().Len(result, 1)
+	suite.Require().Equal(p2.ID, result[0].ID)
+	suite.Require().Equal(uint16(0), result[0].Priority)
+	suite.Require().Equal(p2.Body, result[0].Body)
 
 	//the other should still exists on different partition
-	result, err = suite.messages.GetLowestPriority(topic, 87, 100)
-	suite.Assert().NoError(err)
-	suite.Assert().Len(result, 1)
-	suite.Assert().Equal(key, result[0].ID)
-	suite.Assert().Equal(uint16(87), result[0].Priority)
+	result, err = suite.messages.GetLowestPriority(topicHash, 87, 100)
+	suite.Require().NoError(err)
+	suite.Require().Len(result, 1)
+	suite.Require().Equal(p3.ID, result[0].ID)
+	suite.Require().Equal(p3.Body, result[0].Body)
+	suite.Require().Equal(uint16(87), result[0].Priority)
 }
 
 func (suite *InMemoryMessagesSuite) TestSeparationOfTopics() {
-	key := []byte("key3")
-	topic1 := []byte("topic1")
-	topic2 := []byte("topic2")
+	topic1 := uint32(42)
+	topic2 := uint32(87)
+	topics := []uint32{topic1, topic2}
 
-	for _, t := range [][]byte{topic1, topic2} {
-		p1 := keysToMsgs([][]byte{key}, 42)
-		err := suite.messages.Upsert(t, 42, p1)
-		suite.Assert().NoError(err)
+	p1 := NewMessageWithRandomID(42, []byte("p1body_for_topicTODO"))
+
+	for _, t := range topics {
+		err := suite.messages.Upsert(t, 42, []Message{p1})
+		suite.Require().NoError(err)
 
 		result, err := suite.messages.GetLowestPriority(t, 42, 100)
-		suite.Assert().NoError(err)
-		suite.Assert().Len(result, 1, "msg from another topic was read")
+		suite.Require().NoError(err)
+		suite.Require().Len(result, 1, "msg from another topic was read")
 	}
 
-	err := suite.messages.Ack(topic2, 42, keysToMsgs([][]byte{key}, 42))
-	suite.Assert().NoError(err)
+	err := suite.messages.Ack(topic2, 42, []Message{p1})
+	suite.Require().NoError(err)
 
 	result, err := suite.messages.GetLowestPriority(topic2, 42, 100)
-	suite.Assert().NoError(err)
-	suite.Assert().Len(result, 0)
+	suite.Require().NoError(err)
+	suite.Require().Len(result, 0)
 
 	result, err = suite.messages.GetLowestPriority(topic1, 42, 100)
-	suite.Assert().NoError(err)
-	suite.Assert().Len(result, 1)
-	suite.Assert().Equal(result[0].ID, key)
-	suite.Assert().Equal(result[0].Priority, uint16(42))
+	suite.Require().NoError(err)
+	suite.Require().Len(result, 1)
+	suite.Require().Equal(result[0].ID, p1.ID)
+	suite.Require().Equal(result[0].Priority, uint16(42))
 }
 
 func (suite *InMemoryMessagesSuite) TestOrderedKeysInAPriority() {
-	k1 := []byte("key1")
+	//all keys must have 6 bytes
+	k1 := []byte("key1__")
 	k1a := []byte("key1_a")
 	k1b := []byte("key1_b")
 	k1c := []byte("key1_c")
-	k2 := []byte("key2")
-	k3 := []byte("key3")
-	k4 := []byte("key4")
+	k2 := []byte("key2__")
+	k3 := []byte("key3__")
+	k4 := []byte("key4__")
 
 	tests := []struct {
 		name          string
@@ -128,96 +130,105 @@ func (suite *InMemoryMessagesSuite) TestOrderedKeysInAPriority() {
 	}
 
 	//this also tests Message constructors
+	topic := uint32(7)
 	for _, t := range tests {
 		test := t
 		suite.Run(test.name, func() {
-			err := suite.messages.Upsert([]byte(test.name), 42, keysToMsgs(test.input, 1))
-			suite.Assert().NoError(err)
+			topic++
+			err := suite.messages.Upsert(topic, 42, keysToMsgs(test.input, 1))
+			suite.Require().NoError(err)
 
-			got, err := suite.messages.GetLowestPriority([]byte(test.name), 42, test.limit)
-			suite.Assert().NoError(err)
-			if suite.Assert().Equal(len(test.orderedOutput), len(got)) {
-				for i := range got {
-					suite.Assert().Equal(test.orderedOutput[i], got[i].ID)
-				}
+			got, err := suite.messages.GetLowestPriority(topic, 42, test.limit)
+			suite.Require().NoError(err)
+			suite.Require().Len(got, len(test.orderedOutput))
+			for i := range got {
+				suite.Require().Equal(test.orderedOutput[i], got[i].ID)
 			}
 		})
 	}
 }
 
-func (suite *InMemoryMessagesSuite) TestOrderedKeysInMultiplePrioritiesAndPartitions() {
-	k1 := []byte("key1")
-	k2 := []byte("key2")
-	k3 := []byte("key3")
+//func (suite *InMemoryMessagesSuite) TestOrderedKeysInMultiplePrioritiesAndPartitions() {
+//	k1 := []byte("key1")
+//	k2 := []byte("key2")
+//	k3 := []byte("key3")
+//
+//	//each test will be run for each partition / topic
+//	topics := []uint32{0, 87}
+//	partitions := []uint16{0, 87, 42}
+//
+//	tests := []struct {
+//		name          string
+//		input         []Message
+//		orderedOutput []Message
+//	}{
+//		{
+//			name: "3priorities1msg",
+//			input: flattenSlices(
+//				keysToMsgs([][]byte{k3}, 3),
+//				keysToMsgs([][]byte{k1}, 5),
+//				keysToMsgs([][]byte{k2}, 1),
+//			),
+//			orderedOutput: flattenSlices(
+//				keysToMsgs([][]byte{k2}, 1),
+//				keysToMsgs([][]byte{k3}, 3),
+//				keysToMsgs([][]byte{k1}, 5),
+//			),
+//		},
+//		{
+//			name: "3priorities3msgs",
+//			input: flattenSlices(
+//				keysToMsgs([][]byte{k3, k1, k2}, 3),
+//				keysToMsgs([][]byte{k1, k2, k3}, 5),
+//				keysToMsgs([][]byte{k3, k2, k1}, 1),
+//			),
+//			orderedOutput: flattenSlices(
+//				keysToMsgs([][]byte{k1, k2, k3}, 1),
+//				keysToMsgs([][]byte{k1, k2, k3}, 3),
+//				keysToMsgs([][]byte{k1, k2, k3}, 5),
+//			),
+//		},
+//	}
+//
+//	for _, test := range tests {
+//		for _, topic := range topics {
+//			//this also tests Message constructors
+//			test := test
+//
+//			//we put ALL the data in and then check if it comes out right
+//			for _, partition := range partitions {
+//				err := suite.messages.Upsert(topic, partition, test.input)
+//				suite.Require().NoError(err)
+//			}
+//		}
+//
+//		for _, topic := range topics {
+//			test := test
+//			topic := topic
+//			for _, partition := range partitions {
+//				partition := partition
+//				suite.Run(fmt.Sprintf("%d-%d-%s", topic, partition, test.name), func() {
+//					got, err := suite.messages.GetLowestPriority(topic, partition, 100)
+//					suite.Require().NoError(err)
+//					if suite.Require().Equal(len(test.orderedOutput), len(got)) {
+//						for i := range got {
+//							suite.Require().Equal(test.orderedOutput[i].ID, got[i].ID)
+//							suite.Require().Equal(test.orderedOutput[i].Priority, got[i].Priority)
+//							suite.Require().Equal(test.orderedOutput[i].Body, got[i].Body)
+//						}
+//					}
+//				})
+//			}
+//		}
+//	}
+//}
 
-	//each test will be run for each partition / topic
-	topics := [][]byte{[]byte("topic1")} //, "megatopic"}
-	partitions := []uint16{0, 87, 42}
-
-	tests := []struct {
-		name          string
-		input         []Message
-		orderedOutput []Message
-	}{
-		{
-			name: "3priorities1msg",
-			input: flattenSlices(
-				keysToMsgs([][]byte{k3}, 3),
-				keysToMsgs([][]byte{k1}, 5),
-				keysToMsgs([][]byte{k2}, 1),
-			),
-			orderedOutput: flattenSlices(
-				keysToMsgs([][]byte{k2}, 1),
-				keysToMsgs([][]byte{k3}, 3),
-				keysToMsgs([][]byte{k1}, 5),
-			),
-		},
-		{
-			name: "3priorities3msgs",
-			input: flattenSlices(
-				keysToMsgs([][]byte{k3, k1, k2}, 3),
-				keysToMsgs([][]byte{k1, k2, k3}, 5),
-				keysToMsgs([][]byte{k3, k2, k1}, 1),
-			),
-			orderedOutput: flattenSlices(
-				keysToMsgs([][]byte{k1, k2, k3}, 1),
-				keysToMsgs([][]byte{k1, k2, k3}, 3),
-				keysToMsgs([][]byte{k1, k2, k3}, 5),
-			),
-		},
+func flattenSlices(list ...[]Message) []Message {
+	var result []Message
+	for _, cont := range list {
+		result = append(result, cont...)
 	}
-
-	for _, test := range tests {
-		for _, topic := range topics {
-			//this also tests Message constructors
-			test := test
-
-			//we put ALL the data in and then check if it comes out right
-			for _, partition := range partitions {
-				err := suite.messages.Upsert(topic, partition, test.input)
-				suite.Assert().NoError(err)
-			}
-		}
-
-		for _, topic := range topics {
-			test := test
-			topic := topic
-			for _, partition := range partitions {
-				partition := partition
-				suite.Run(fmt.Sprintf("%s-%d-%s", topic, partition, test.name), func() {
-					got, err := suite.messages.GetLowestPriority(topic, partition, 100)
-					suite.Assert().NoError(err)
-					if suite.Assert().Equal(len(test.orderedOutput), len(got)) {
-						for i := range got {
-							suite.Assert().Equal(test.orderedOutput[i].ID, got[i].ID)
-							suite.Assert().Equal(test.orderedOutput[i].Priority, got[i].Priority)
-							suite.Assert().Equal(test.orderedOutput[i].Body, got[i].Body)
-						}
-					}
-				})
-			}
-		}
-	}
+	return result
 }
 
 func keysToMsgs(in [][]byte, priority uint16) []Message {
@@ -228,14 +239,6 @@ func keysToMsgs(in [][]byte, priority uint16) []Message {
 			Priority: priority,
 			Body:     append([]byte("body_"), in[i]...),
 		}
-	}
-	return result
-}
-
-func flattenSlices(list ...[]Message) []Message {
-	var result []Message
-	for _, cont := range list {
-		result = append(result, cont...)
 	}
 	return result
 }

--- a/storage/storage_metadata_integration_test.go
+++ b/storage/storage_metadata_integration_test.go
@@ -80,13 +80,13 @@ func (suite *InMemoryMetadataSuite) TestCreateTopicsMetadata() {
 			}
 			suite.Require().Equal(test.inputID, mtInsert.TopicID)
 			suite.Require().Equal(test.inputParts, mtInsert.PartitionsCount)
-			suite.Require().NotEmpty(mtInsert.TopicUUID)
+			suite.Require().NotEmpty(mtInsert.TopicHash)
 
 			mt, err := suite.metadata.TopicMetadata(test.inputID)
 			suite.Require().NoError(err)
 			suite.Require().Equal(test.inputID, mt.TopicID)
 			suite.Require().Equal(test.inputParts, mt.PartitionsCount)
-			suite.Require().Equal(mtInsert.TopicUUID, mt.TopicUUID)
+			suite.Require().Equal(mtInsert.TopicHash, mt.TopicHash)
 		})
 	}
 
@@ -109,20 +109,20 @@ func (suite *InMemoryMetadataSuite) TestCreateTopicsMetadata() {
 }
 
 func (suite *InMemoryMetadataSuite) TestConsumersMetadata() {
-	topics := []string{"topic1", "lastone"}
+	topics := []uint32{0, 87}
 
 	c1 := ConsumerMetadata{
-		TopicUUID:  topics[0],
+		TopicHash:  topics[0],
 		ConsumerID: "cons1",
 		LastSeen:   time.Now().UTC().Round(time.Second),
 	}
 	c2 := ConsumerMetadata{
-		TopicUUID:  topics[0],
+		TopicHash:  topics[0],
 		ConsumerID: "cons2",
 		LastSeen:   time.Now().UTC().Round(time.Second).Add(time.Hour),
 	}
 	c3 := ConsumerMetadata{
-		TopicUUID:  topics[1],
+		TopicHash:  topics[1],
 		ConsumerID: "cons1TTopic2",
 		LastSeen:   time.Now().UTC().Round(time.Second).Add(3 * time.Hour),
 	}
@@ -131,10 +131,12 @@ func (suite *InMemoryMetadataSuite) TestConsumersMetadata() {
 		name  string
 		input []ConsumerMetadata
 	}{
-		{name: "fewConsumers",
+		{
+			name:  "fewConsumers",
 			input: []ConsumerMetadata{c3, c1, c2},
 		},
-		{name: "onlyOneTopic",
+		{
+			name:  "onlyOneTopic",
 			input: []ConsumerMetadata{c3},
 		},
 	}
@@ -148,13 +150,27 @@ func (suite *InMemoryMetadataSuite) TestConsumersMetadata() {
 			suite.Require().NoError(err)
 
 			//test GET for each topic
-			var gotCons []ConsumerMetadata
 			for _, topic := range topics {
 				got, errGet := suite.metadata.ConsumersMetadata(topic)
 				suite.Require().NoError(errGet)
-				gotCons = append(gotCons, got...)
+
+				shouldHaveLen := 0
+				for _, wantedCM := range test.input {
+					if wantedCM.TopicHash != topic {
+						continue
+					}
+					shouldHaveLen++
+					var found bool
+					for _, gotCM := range got {
+						if gotCM.ConsumerID == wantedCM.ConsumerID {
+							found = true
+							break
+						}
+					}
+					suite.Require().True(found, "missing consumerID %s in topic %d", wantedCM.ConsumerID, topic)
+				}
+				suite.Require().Len(got, shouldHaveLen, "we received more consumers than supposed to")
 			}
-			suite.Require().ElementsMatch(test.input, gotCons)
 
 			//remove all of them
 			err = suite.metadata.RemoveConsumers(test.input)
@@ -172,7 +188,7 @@ func (suite *InMemoryMetadataSuite) TestConsumersMetadata() {
 }
 
 func (suite *InMemoryMetadataSuite) TestConsumersPartitions() {
-	topics := []string{"topic1", "lastone"}
+	topics := []uint32{2, 87}
 
 	cp1 := ConsumerPartitions{
 		ConsumerID: "cons1",
@@ -189,7 +205,10 @@ func (suite *InMemoryMetadataSuite) TestConsumersPartitions() {
 	cons := []ConsumerPartitions{cp2, cp3, cp1}
 
 	for _, topic := range topics {
-		err := suite.metadata.UpsertConsumerPartitions(topic, cons)
+		for _, c := range cons {
+			c.TopicHash = topic
+		}
+		err := suite.metadata.UpsertConsumerPartitions(cons)
 		suite.Require().NoError(err)
 	}
 
@@ -217,7 +236,7 @@ func (suite *InMemoryMetadataSuite) TestConsumersPartitions() {
 }
 
 func (suite *InMemoryMetadataSuite) TestDeleteConsumer() {
-	topics := []string{"topic1", "topic2"}
+	topics := []uint32{2, 87}
 
 	cp1 := ConsumerPartitions{
 		ConsumerID: "cons1",
@@ -236,8 +255,8 @@ func (suite *InMemoryMetadataSuite) TestDeleteConsumer() {
 		LastSeen:   time.Now().UTC().Round(time.Second).Add(time.Hour),
 	}
 
-	consExistsIn := func(shouldExists bool, topic string, consumerID string) {
-		consMeta, err := suite.metadata.ConsumersMetadata(topic)
+	consExistsIn := func(shouldExists bool, topicHash uint32, consumerID string) {
+		consMeta, err := suite.metadata.ConsumersMetadata(topicHash)
 		suite.Require().NoError(err)
 
 		var found bool
@@ -248,10 +267,10 @@ func (suite *InMemoryMetadataSuite) TestDeleteConsumer() {
 			}
 		}
 		suite.Require().Equal(shouldExists, found,
-			"state of consumer in consumer metadata is wrong exp %v got %v for  %s topic %s",
-			shouldExists, found, consumerID, topic)
+			"state of consumer in consumer metadata is wrong exp %v got %v for  %s topicHash %d",
+			shouldExists, found, consumerID, topicHash)
 
-		consParts, err := suite.metadata.ConsumerPartitions(topic)
+		consParts, err := suite.metadata.ConsumerPartitions(topicHash)
 		suite.Require().NoError(err)
 
 		for _, cn := range consParts {
@@ -262,18 +281,20 @@ func (suite *InMemoryMetadataSuite) TestDeleteConsumer() {
 		}
 		suite.Require().Equal(
 			shouldExists, found,
-			"state of consumer in consumer partitions is wrong exp %v got %v for  %s topic %s",
-			shouldExists, found, consumerID, topic)
+			"state of consumer in consumer partitions is wrong exp %v got %v for  %s topicHash %d",
+			shouldExists, found, consumerID, topicHash)
 	}
 
 	//add all of them
 	for _, topic := range topics {
-		c1.TopicUUID = topic
-		c2.TopicUUID = topic
+		c1.TopicHash = topic
+		c2.TopicHash = topic
 		err := suite.metadata.UpsertConsumersMetadata([]ConsumerMetadata{c1, c2})
 		suite.Require().NoError(err)
 
-		err = suite.metadata.UpsertConsumerPartitions(topic, []ConsumerPartitions{cp1, cp2})
+		cp1.TopicHash = topic
+		cp2.TopicHash = topic
+		err = suite.metadata.UpsertConsumerPartitions([]ConsumerPartitions{cp1, cp2})
 		suite.Require().NoError(err)
 	}
 
@@ -285,7 +306,7 @@ func (suite *InMemoryMetadataSuite) TestDeleteConsumer() {
 	consExistsIn(true, topics[1], c1.ConsumerID)
 	consExistsIn(true, topics[1], c2.ConsumerID)
 
-	c2.TopicUUID = topics[1]
+	c2.TopicHash = topics[1]
 	err := suite.metadata.RemoveConsumers([]ConsumerMetadata{c2})
 	suite.Require().NoError(err)
 	consExistsIn(true, topics[0], c1.ConsumerID)


### PR DESCRIPTION
This PR address the followings:
* lower the size of topicUUID and made a uint32 simple murmur3 hash
* cleanup the Prefix logic into methods (it was a mess)
* replaced helpers with builtin binary package